### PR TITLE
Add php phar module for extended archive support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN set -xe; \
         php5-soap \
         php5-pcntl \
         php5-xml \
+        php5-phar \
         php5-zip
 
 RUN mkdir -p /run/apache2 \


### PR DESCRIPTION
The support for additional archive formats introduced with #44 requires
the php phar module.

Therefore adding the corresponding alpine package to the docker image.