### PR TITLE
Support third-party EPUB reader

### DIFF
--- a/src/ifm.js
+++ b/src/ifm.js
@@ -169,18 +169,28 @@ function IFM(params) {
 				}
 			}
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
-			if( self.config.isDocroot && !self.config.forceproxy )
-				item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
-			else if (self.config.download && self.config.zipnload) {
-				if (self.config.root_public_url) {
-					if (self.config.root_public_url.charAt(0) == "/")
-						item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-					else
-						item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-				} else
-					item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
-			} else
-				item.link = '#';
+				if( self.config.isDocroot && !self.config.forceproxy )
+					if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+						item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+item.name;
+					} else
+						item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
+                else if (self.config.download && self.config.zipnload) {
+                    if (self.config.root_public_url) {
+						if (self.config.root_public_url.charAt(0) == "/")
+							if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+								item.link = self.config.epub_path+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+							} else
+								item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						else
+							if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+								item.link = self.config.epub_path+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+							} else
+								item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+                    } else
+                        item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
+                } else
+                    item.link = '#';
+
 			if( ! self.inArray( item.name, [".", ".."] ) ) {
 				item.dragdrop = 'draggable="true"';
 				if( self.config.copymove )

--- a/src/ifm.js
+++ b/src/ifm.js
@@ -190,7 +190,6 @@ function IFM(params) {
 					item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 			} else
 				item.link = '#';
-
 			if( ! self.inArray( item.name, [".", ".."] ) ) {
 				item.dragdrop = 'draggable="true"';
 				if( self.config.copymove )

--- a/src/ifm.js
+++ b/src/ifm.js
@@ -171,19 +171,19 @@ function IFM(params) {
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 			if( self.config.isDocroot && !self.config.forceproxy )
 				if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-					item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+self.hrefEncode( self.pathCombine( self.currentDir, item.name ) );
+					item.link = self.config.epub_reader_url+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+self.hrefEncode( self.pathCombine( self.currentDir, item.name ) );
 				} else
 					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
 			else if (self.config.download && self.config.zipnload) {
 				if (self.config.root_public_url) {
 					if (self.config.root_public_url.charAt(0) == "/")
 						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-							item.link = self.config.epub_path+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+							item.link = self.config.epub_reader_url+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 						} else
 							item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 					else
 						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-							item.link = self.config.epub_path+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+							item.link = self.config.epub_reader_url+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 						} else
 							item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
 				} else

--- a/src/ifm.js
+++ b/src/ifm.js
@@ -171,7 +171,7 @@ function IFM(params) {
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
 			if( self.config.isDocroot && !self.config.forceproxy )
 				if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-					item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+item.name;
+					item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+self.hrefEncode( self.pathCombine( self.currentDir, item.name ) );
 				} else
 					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
 			else if (self.config.download && self.config.zipnload) {

--- a/src/ifm.js
+++ b/src/ifm.js
@@ -169,27 +169,27 @@ function IFM(params) {
 				}
 			}
 			item.download.link = self.api+"?api="+item.download.action+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
-				if( self.config.isDocroot && !self.config.forceproxy )
-					if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-						item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+item.name;
-					} else
-						item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
-                else if (self.config.download && self.config.zipnload) {
-                    if (self.config.root_public_url) {
-						if (self.config.root_public_url.charAt(0) == "/")
-							if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-								item.link = self.config.epub_path+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-							} else
-								item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-						else
-							if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
-								item.link = self.config.epub_path+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-							} else
-								item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
-                    } else
-                        item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
-                } else
-                    item.link = '#';
+			if( self.config.isDocroot && !self.config.forceproxy )
+				if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+					item.link = self.config.epub_path+self.api.substring(0, self.api.lastIndexOf('/'))+"/"+item.name;
+				} else
+					item.link = self.hrefEncode( self.pathCombine( window.location.path, self.currentDir, item.name ) );
+			else if (self.config.download && self.config.zipnload) {
+				if (self.config.root_public_url) {
+					if (self.config.root_public_url.charAt(0) == "/")
+						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+							item.link = self.config.epub_path+self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						} else
+							item.link = self.pathCombine(window.location.origin, self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+					else
+						if( self.config.epub_reader && item.name.split(/[#?]/)[0].split('.').pop().trim() == "epub" ) {
+							item.link = self.config.epub_path+self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+						} else
+							item.link = self.pathCombine(self.config.root_public_url, self.hrefEncode(self.currentDir), self.hrefEncode(item.name) );
+				} else
+					item.link = self.api+"?api="+(item.download.action=="zipnload"?"zipnload":"proxy")+"&dir="+self.hrefEncode(self.currentDir)+"&filename="+self.hrefEncode(item.download.name);
+			} else
+				item.link = '#';
 
 			if( ! self.inArray( item.name, [".", ".."] ) ) {
 				item.dragdrop = 'draggable="true"';

--- a/src/main.php
+++ b/src/main.php
@@ -68,7 +68,9 @@ class IFM {
 		"disable_mime_detection" => 0,
 		"showrefresh" => 1,
 		"forceproxy" => 0,
-		"confirmoverwrite" => 1
+		"confirmoverwrite" => 1,
+		"epub_reader" => 0,
+		"epub_path" => 'https://futurepress.github.io/epubjs-reader/index.html?bookPath='
 	];
 
 	private $config = [];

--- a/src/main.php
+++ b/src/main.php
@@ -70,7 +70,7 @@ class IFM {
 		"forceproxy" => 0,
 		"confirmoverwrite" => 1,
 		"epub_reader" => 0,
-		"epub_path" => 'https://futurepress.github.io/epubjs-reader/index.html?bookPath='
+		"epub_reader_url" => 'https://futurepress.github.io/epubjs-reader/index.html?bookPath='
 	];
 
 	private $config = [];


### PR DESCRIPTION
This is something I have been trying to implement for my own use case. Adding here in case valuable to the larger project. When enabled in the config, clicking an EPUB file in IFM will take you to a third-party EPUB reader to display it rather than download the file (file can still be downloaded via the download button of course), making it more like how JPEGs and text documents work. 

The third-party reader is open-source under an MIT License, so can also be pulled and run on someones own server, and can then redirect to that reader via the `epub_path` config variable. 

Here are some other open source readers that can also be used: 
https://github.com/readium/readium-js-viewer#cloud-reader-deployment
https://github.com/satorumurmur/bibi

Will document accordingly. 

I forked the code from v4.0 and built from there as it seemed there were such significant changes, it would be easier to merge this way if you decide to include it.

Personally I feel this is going to benefit too few people to have it merged, but worse case scenario at least there will be an example here in the closed pull request for someone in the future.  

Note, PHP/JS isn't my mother-tongue language so a thorough look will be necessary, and by all means feel free to edit directly. 