### PR TITLE
Perf/http cache opcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,11 @@ RUN apk add --no-cache \
     zip
 
 # add missing extensions (runtime)
+# note: opcache is compiled in statically since PHP 8.5, only ini settings needed
 RUN docker-php-ext-install \
     bz2 \
     fileinfo \
     ldap \
-    opcache \
     posix \
     zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN docker-php-ext-install \
     bz2 \
     fileinfo \
     ldap \
+    opcache \
     posix \
     zip
 

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,3 +1,11 @@
 max_execution_time = 0
 upload_max_filesize = 0
 post_max_size = 0
+
+; ifm is one big generated PHP file; opcache keeps its compiled form in memory
+; instead of re-parsing it on every request of the built-in server.
+; cli-server SAPI honors opcache.enable; enable_cli covers plain cli runs too.
+opcache.enable = 1
+opcache.enable_cli = 1
+opcache.memory_consumption = 64
+opcache.revalidate_freq = 2

--- a/src/main.php
+++ b/src/main.php
@@ -689,7 +689,7 @@ f00bar;
 		if (!is_file($d['filename']))
 			http_response_code(404);
 		else
-			$this->fileDownload(["file" => $d['filename'], "forceDL" => $forceDL]);
+			$this->fileDownload(["file" => $d['filename'], "forceDL" => $forceDL, "cache" => true]);
 	}
 
 	// extracts a zip-archive
@@ -1422,9 +1422,29 @@ f00bar;
 			$content_type = mime_content_type($options['file']);
 
 		header('Content-Type: '.$content_type);
-		header('Expires: 0');
-		header('Cache-Control: must-revalidate');
-		header('Pragma: public');
+
+		if (!empty($options['cache'])) {
+			// no-cache means "store, but revalidate before use": browsers keep a copy
+			// and get a bodyless 304 unless the file changed
+			$mtime = filemtime($options['file']);
+			$etag = sprintf('"%x-%x"', $mtime, filesize($options['file']));
+			header('ETag: '.$etag);
+			header('Last-Modified: '.gmdate('D, d M Y H:i:s', $mtime).' GMT');
+			header('Cache-Control: private, no-cache');
+
+			// If-None-Match takes precedence over If-Modified-Since (RFC 9110 13.1.3)
+			$inm = $_SERVER['HTTP_IF_NONE_MATCH'] ?? '';
+			$ims = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) : false;
+			if ($inm !== '' ? in_array($etag, array_map('trim', explode(',', $inm)), true) : ($ims !== false && $ims >= $mtime)) {
+				http_response_code(304);
+				return;
+			}
+		} else {
+			header('Expires: 0');
+			header('Cache-Control: must-revalidate');
+			header('Pragma: public');
+		}
+
 		header('Content-Length: '.filesize($options['file']));
 
 		while (ob_get_level() > 0)


### PR DESCRIPTION
perf: HTTP conditional requests for downloads, opcache in Docker

- fileDownload: emit ETag (mtime+size) and Last-Modified for files
  served via the download/proxy API and answer If-None-Match /
  If-Modified-Since with a bodyless 304
- Cache-Control "private, no-cache": browsers keep a copy but always
  revalidate, so previews stay fresh while repeated views of unchanged
  files cost only a header exchange
- generated archives (zipnload) keep the old headers: a one-off tmp
  file has nothing to revalidate
- Docker: enable opcache for the built-in server via php.ini; the app
  is a single ~1.5 MB generated PHP file that was re-parsed on every
  request without it (opcache itself is compiled into PHP statically
  since 8.5, nothing to install)